### PR TITLE
Update broken link

### DIFF
--- a/_data/people.yml
+++ b/_data/people.yml
@@ -465,7 +465,7 @@
 - id: Kihong Heo
   name: Kihong Heo
   status: external
-  website: https://www.cis.upenn.edu/~kheo/
+  website: https://kihongheo.kaist.ac.kr/
 
 - id: Wonchan Lee
   name: Wonchan Lee


### PR DESCRIPTION
* Global Sparse Analysis Framework 저자들의 링크 중 허기홍 교수님, 이원찬 님의 링크가 살이있는 주소가 아니였습니다.
* 허기홍 교수님 링크는 업데이트를 했습니다.
* 이원찬 님의 링크는 좀 찾아봤는데 더이상 maintain을 하시는 홈페이지 링크가 없는것 같아 일단 그대로 뒀습니다.