### PR TITLE
Add instructions on using VSCode Dev Containers to deploy locally

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/jekyll
+{
+	"name": "Jekyll",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/jekyll:2-bullseye"
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Uncomment the next line to run commands after the container is created.
+	// "postCreateCommand": "jekyll --version"
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-### Build and serve
+## Build and Serve
 
 You have the option to build the website either in a remote [Coder Workspace](#coder-workspace) or your local [VSCode using the Dev Container feature](#vscode-dev-containers).
 
-#### Coder Workspace
+### Coder Workspace
 
-Inside a Coder workspace (<https://dev.fearless.systems>),
+Within a Coder workspace (<https://dev.fearless.systems>), run the following commands:
 
 ```bash
 $ sudo apt install -y bundler
@@ -12,24 +12,24 @@ $ sudo bundle install --system
 $ bundle exec jekyll serve
 ```
 
-Then you can see the website with Coder's port forwarding feature.
+Afterward, view the website using Coder's port forwarding feature.
 
-#### VSCode Dev Containers
+### VSCode Dev Containers
 
-Activate the [Dev Containers feature](https://code.visualstudio.com/docs/devcontainers/containers#_getting-started) in your local VSCode, and reopen the workspace in a Jekyll container by simply running `Dev Containers: Reopen in Container`.
+Enable the [Dev Containers feature](https://code.visualstudio.com/docs/devcontainers/containers#_getting-started) in your local VSCode and reopen the workspace in a Jekyll container by simply running `Dev Containers: Reopen in Container`.
 
-Inside the container,
+Within the container, run the following commands:
 
 ```bash
 $ bundle install
 $ bundle exec jekyll serve
 ```
 
-Then you can see the website with VSCode's port forwarding feature.
+Afterward, view the website using VSCode's port forwarding feature.
 
-### Create your website
+## Create Your Website
 
 - Add your information (e.g., name, status, GitHub ID) to `people.yml`.
 
-- Create a new file `{firstname}.{lastname}.md` under the directory `_people/`. See `_people/jeehoon.kang.md` for a reference.
-  Your website is `https://www.fearless.systems/{firstname}.{lastname}`.
+- Create a new file `{firstname}.{lastname}.md` under the directory `_people/`. Refer to `_people/jeehoon.kang.md` as an example.
+  Your website will be accessible at `https://www.fearless.systems/{firstname}.{lastname}`.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 ### Build and serve
 
+You have the option to build the website either in a remote [Coder Workspace](#coder-workspace) or your local [VSCode using the Dev Container feature](#vscode-dev-containers).
+
+#### Coder Workspace
+
 Inside a Coder workspace (<https://dev.fearless.systems>),
 
 ```bash
@@ -10,6 +14,18 @@ $ bundle exec jekyll serve
 
 Then you can see the website with Coder's port forwarding feature.
 
+#### VSCode Dev Containers
+
+Activate the [Dev Containers feature](https://code.visualstudio.com/docs/devcontainers/containers#_getting-started) in your local VSCode, and reopen the workspace in a Jekyll container by simply running `Dev Containers: Reopen in Container`.
+
+Inside the container,
+
+```bash
+$ bundle install
+$ bundle exec jekyll serve
+```
+
+Then you can see the website with VSCode's port forwarding feature.
 
 ### Create your website
 


### PR DESCRIPTION
Jekyll이 로컬 환경을 많이 타는 것 같습니다. Coder에서 빌드가 안되거나, 로컬에 설치해도 오류가 나는 경우가 았습니다 ([Example](https://chat.fearless.systems/#narrow/stream/118-discussion/topic/homepage/near/365808)). 그래서 Jekyll container를 VSCode로 pull 해와서 빌드하는 방법을 추가해두는 것이 도움이 될 것 같다고 생각했습니다.

* README에 VSCode Dev Containers 기능으로 빌드하는 방법을 추가했습니다.
  * 추가한 instruction대로 따라가면, Mac / Linux 모두 Docker + VSCode 조합으로 잘 빌드됩니다.
* README에 있던 부자연스로운 표현들을 ChatGPT로 수정했습니다.